### PR TITLE
Cargo.toml: Add some more metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "healthdog"
 version = "0.1.0"
 authors = ["Petros Angelatos <petrosagg@gmail.com>"]
+description = "Helper program that connects external periodic heathchecks with systemd's watchdog support"
+repository = "https://github.com/resin-os/healthdog-rs.git"
+license = "Apache-2.0"
+license_file = "LICENSE"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION

This is required for ```cargo bitbake```.

Signed-off-by: Will Newton <willn@resin.io>