### PR TITLE
Cargo.toml: Remove panic = abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Petros Angelatos <petrosagg@gmail.com>"]
 description = "Helper program that connects external periodic heathchecks with systemd's watchdog support"
 repository = "https://github.com/resin-os/healthdog-rs.git"
 license = "Apache-2.0"
-license_file = "LICENSE"
 
 [dependencies]
 libc = "0.2"
@@ -16,4 +15,3 @@ nix = "0.8.0"
 
 [profile.release]
 lto = true
-panic = 'abort'


### PR DESCRIPTION
This seems to cause problems with the toolchain from meta-rust.

Signed-off-by: Will Newton <willn@resin.io>