### PR TITLE
Cargo.toml: Remove LTO from release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,3 @@ getopts = "0.2.4"
 exec = "0.3.1"
 nix = "0.8.0"
 
-[profile.release]
-lto = true


### PR DESCRIPTION
LTO seems incompatible with dynamic linking with Rust:

| error: cannot prefer dynamic linking when performing LTO
|   |
|   = note: only 'staticlib', 'bin', and 'cdylib' outputs are supported with LTO

Signed-off-by: Will Newton <willn@resin.io>